### PR TITLE
Add Missing Galaxy Guide Languages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -309,6 +309,7 @@
             "Diasporan": "Diasporan",
             "Eoxian": "Eoxian",
             "Jinsul": "Jinsul",
+            "Kalo": "Kalo",
             "Kasatha": "Kasatha",
             "Khizar": "Khizar",
             "Kothama": "Kothama",
@@ -318,12 +319,15 @@
             "PactCommon": "Pact Common",
             "Pahtra": "Pahtra",
             "Prelurian": "Prelurian",
+            "Sarcesian": "Sarcesian",
+            "SarcesianSigned": "Sarcesian (signed)",
             "Shirren": "Shirren",
             "Shobhad": "Shobhad",
             "Triaxian": "Triaxian",
             "Trinary": "Trinary",
             "Vercite": "Vercite",
-            "Vesk": "Vesk"
+            "Vesk": "Vesk",
+            "Vlaka": "Vlaka"
         },
         "NPCAbility": {
             "Hardlight": {

--- a/module.json
+++ b/module.json
@@ -465,6 +465,7 @@
                     "diasporan": "SF2E.Language.Diasporan",
                     "eoxian": "SF2E.Language.Eoxian",
                     "jinsul": "SF2E.Language.Jinsul",
+                    "kalo": "SF2E.Language.Kalo",
                     "kasatha": "SF2E.Language.Kasatha",
                     "khizar": "SF2E.Language.Khizar",
                     "kothama": "SF2E.Language.Kothama",
@@ -472,11 +473,14 @@
                     "pact-common": "SF2E.Language.PactCommon",
                     "pahtra": "SF2E.Language.Pahtra",
                     "prelurian": "SF2E.Language.Prelurian",
+                    "sarcesian": "SF2E.Language.Sarcesian",
+                    "sarcesian-signed": "SF2E.Language.SarcesianSigned",
                     "shirren": "SF2E.Language.Shirren",
                     "triaxian": "SF2E.Language.Triaxian",
                     "trinary": "SF2E.Language.Trinary",
                     "vercite": "SF2E.Language.Vercite",
                     "vesk": "SF2E.Language.Vesk",
+                    "vlaka": "SF2E.Language.Vlaka",
                     "morandomandranan": "SF2E.Language.Morandomandranan"
                 },
                 "weaponGroups": {

--- a/packs/ancestries/Kalo_23MA5Ee7ExUfzrqk.json
+++ b/packs/ancestries/Kalo_23MA5Ee7ExUfzrqk.json
@@ -70,7 +70,8 @@
     },
     "languages": {
       "value": [
-        "common"
+        "common",
+        "kalo"
       ],
       "custom": ""
     },
@@ -100,9 +101,9 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "pf2e",
-    "systemVersion": "7.2.3",
+    "systemVersion": "7.3.1",
     "exportSource": null
   },
   "_id": "23MA5Ee7ExUfzrqk",

--- a/packs/ancestries/Sarcesian_i1fnTVBTRYSqFY2c.json
+++ b/packs/ancestries/Sarcesian_i1fnTVBTRYSqFY2c.json
@@ -63,7 +63,9 @@
     },
     "languages": {
       "value": [
-        "common"
+        "common",
+        "sarcesian",
+        "sarcesian-signed"
       ],
       "custom": ""
     },
@@ -93,9 +95,9 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "pf2e",
-    "systemVersion": "7.2.3",
+    "systemVersion": "7.3.1",
     "exportSource": null
   },
   "_id": "i1fnTVBTRYSqFY2c",

--- a/packs/ancestries/Vlaka_mBsOLC7cRc7nkzV2.json
+++ b/packs/ancestries/Vlaka_mBsOLC7cRc7nkzV2.json
@@ -63,7 +63,8 @@
     },
     "languages": {
       "value": [
-        "common"
+        "common",
+        "vlaka"
       ],
       "custom": ""
     },
@@ -100,9 +101,9 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "13.346",
+    "coreVersion": "13.347",
     "systemId": "pf2e",
-    "systemVersion": "7.2.3",
+    "systemVersion": "7.3.1",
     "exportSource": null
   },
   "_key": "!items!mBsOLC7cRc7nkzV2"


### PR DESCRIPTION
Added Kalo, Sarcesian, Sarcesian (signed), and Vlaka languages from Galaxy Guide and assigned them to their respective ancestries. If we don't want to have the signed version of Sarcesian be a distinct language then we can take that out, but it's listed distinctly in the ancestry entry.