### PR TITLE
Fix Mystic Archetype's Vitality Network capacity

### DIFF
--- a/packs/feats/Vitality_Network_kK5JtGm6PQh7DT7Q.json
+++ b/packs/feats/Vitality_Network_kK5JtGm6PQh7DT7Q.json
@@ -32,7 +32,7 @@
       },
       {
         "key": "SpecialResource",
-        "max": "min(10 * floor(@actor.level / 5), 10)"
+        "max": "max(10 * floor(@actor.level / 5), 10)"
       }
     ],
     "slug": "vitality-network",


### PR DESCRIPTION
```json
{
  "key": "SpecialResource",
  "max": "min(10 * floor(@actor.level / 5), 10)"
}
```
Currently has Vitality Network capping at 0 from 1st-4th level and 10 from 5th-20th.

```json
{
  "key": "SpecialResource",
  "max": "max(10 * floor(@actor.level / 5), 10)"
}
```

Scales correctly.