### PR TITLE
adjust the weight, equip type, and runes for Hardlight Handwraps

### DIFF
--- a/packs/equipment/Hardlight_Handwraps__Advanced__pwN8Bh8amBjBPka4.json
+++ b/packs/equipment/Hardlight_Handwraps__Advanced__pwN8Bh8amBjBPka4.json
@@ -37,7 +37,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -77,7 +77,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",
@@ -99,8 +99,8 @@
       "value": null
     },
     "runes": {
-      "potency": 0,
-      "striking": 0,
+      "potency": 1,
+      "striking": 1,
       "property": []
     },
     "specific": null,

--- a/packs/equipment/Hardlight_Handwraps__Commercial__b12tnjobe9IrphII.json
+++ b/packs/equipment/Hardlight_Handwraps__Commercial__b12tnjobe9IrphII.json
@@ -36,7 +36,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -76,7 +76,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",

--- a/packs/equipment/Hardlight_Handwraps__Elite__Q2wVgoS7y1JlciTV.json
+++ b/packs/equipment/Hardlight_Handwraps__Elite__Q2wVgoS7y1JlciTV.json
@@ -37,7 +37,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -74,7 +74,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",
@@ -96,8 +96,8 @@
       "value": null
     },
     "runes": {
-      "potency": 0,
-      "striking": 0,
+      "potency": 2,
+      "striking": 2,
       "property": []
     },
     "specific": null,

--- a/packs/equipment/Hardlight_Handwraps__Paragon__xIyau4fBsCcoLB9x.json
+++ b/packs/equipment/Hardlight_Handwraps__Paragon__xIyau4fBsCcoLB9x.json
@@ -37,7 +37,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -77,7 +77,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",
@@ -99,8 +99,8 @@
       "value": null
     },
     "runes": {
-      "potency": 0,
-      "striking": 0,
+      "potency": 3,
+      "striking": 3,
       "property": []
     },
     "specific": null,

--- a/packs/equipment/Hardlight_Handwraps__Superior__MeV8qRq6cMlSBC2E.json
+++ b/packs/equipment/Hardlight_Handwraps__Superior__MeV8qRq6cMlSBC2E.json
@@ -37,7 +37,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -74,7 +74,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",
@@ -96,8 +96,8 @@
       "value": null
     },
     "runes": {
-      "potency": 0,
-      "striking": 0,
+      "potency": 2,
+      "striking": 1,
       "property": []
     },
     "specific": null,

--- a/packs/equipment/Hardlight_Handwraps__Tactical__xJBRvJHRz7KHAlpj.json
+++ b/packs/equipment/Hardlight_Handwraps__Tactical__xJBRvJHRz7KHAlpj.json
@@ -37,7 +37,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -74,7 +74,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",
@@ -96,7 +96,7 @@
       "value": null
     },
     "runes": {
-      "potency": 0,
+      "potency": 1,
       "striking": 0,
       "property": []
     },

--- a/packs/equipment/Hardlight_Handwraps__Ultimate__Vp7O4NTBJ5OZwGMG.json
+++ b/packs/equipment/Hardlight_Handwraps__Ultimate__Vp7O4NTBJ5OZwGMG.json
@@ -37,7 +37,7 @@
     "quantity": 1,
     "baseItem": null,
     "bulk": {
-      "value": 0.1
+      "value": 0
     },
     "hp": {
       "value": 0,
@@ -77,7 +77,7 @@
       "misidentified": {}
     },
     "usage": {
-      "value": "held-in-one-hand"
+      "value": "worngloves"
     },
     "category": "unarmed",
     "group": "brawling",
@@ -99,8 +99,8 @@
       "value": null
     },
     "runes": {
-      "potency": 0,
-      "striking": 0,
+      "potency": 3,
+      "striking": 2,
       "property": []
     },
     "specific": null,


### PR DESCRIPTION
The weight and equip options for all the Hardlight Handwraps were off, as were the potency and striking values for the various versions. This does NOT solve the problem of the handwraps not affecting an unarmed attack though. 