### PR TITLE
Change 'lead by example' attack toggle to default to on

### DIFF
--- a/packs/feat-effects/Effect__Get__Em__ey2zSEnprAGgvrij.json
+++ b/packs/feat-effects/Effect__Get__Em__ey2zSEnprAGgvrij.json
@@ -54,6 +54,7 @@
         "key": "RollOption",
         "option": "get-em:lead-by-example-strike",
         "toggleable": true,
+        "value": true,
         "predicate": [
           "self:signature:{item|origin.signature}",
           "get-em:lead-by-example"


### PR DESCRIPTION
Does this need its own PR? Probably not.

I wanted to put this forward as I noticed it a lot in my Guilt campaign & Starfinder Societies sessions - players found the current flow clunky of having to apply get 'em -> activate the toggle box -> attack to be rather clunky. This change will make it so that the player will have it enabled by default (and for any potential subsequent attacks they'll need to toggle it off).