### PR TITLE
Implement several creature improvements

### DIFF
--- a/packs/alien-core-bestiary/Cosmic_Dragon__Adult__Spellcaster__T3lt2o82IHEktluT.json
+++ b/packs/alien-core-bestiary/Cosmic_Dragon__Adult__Spellcaster__T3lt2o82IHEktluT.json
@@ -1441,7 +1441,7 @@
           "value": "action"
         },
         "description": {
-          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li>Graviton Each creature must succeed at a @Check[fortitude|dc:34] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p>Photon Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p><p></p></li></ul>",
+          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li><strong>Graviton</strong> Each creature must succeed at a @Check[fortitude|dc:34] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p><strong>Photon</strong> Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p></li></ul>",
           "gm": ""
         },
         "publication": {
@@ -1483,9 +1483,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Cosmic_Dragon__Adult__n63B8xolb2fmYFVE.json
+++ b/packs/alien-core-bestiary/Cosmic_Dragon__Adult__n63B8xolb2fmYFVE.json
@@ -1564,7 +1564,7 @@
           "value": "action"
         },
         "description": {
-          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li>Graviton Each creature must succeed at a @Check[fortitude|dc:34] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p>Photon Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p><p></p></li></ul>",
+          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li><strong>Graviton</strong> Each creature must succeed at a @Check[fortitude|dc:34] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p><strong>Photon</strong> Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p></li></ul>",
           "gm": ""
         },
         "publication": {
@@ -1606,9 +1606,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Cosmic_Dragon__Ancient__OSC3irjEAan8Jhlm.json
+++ b/packs/alien-core-bestiary/Cosmic_Dragon__Ancient__OSC3irjEAan8Jhlm.json
@@ -1565,7 +1565,7 @@
           "value": "action"
         },
         "description": {
-          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The dragon can choose either option for each creature, regardless of their current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li>Graviton Each creature must succeed at a @Check[fortitude|dc:41] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p>Photon Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p><p></p></li></ul>",
+          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The dragon can choose either option for each creature, regardless of their current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li><strong>Graviton</strong> Each creature must succeed at a @Check[fortitude|dc:41] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p><strong>Photon</strong> Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p></li></ul>",
           "gm": ""
         },
         "publication": {
@@ -1607,9 +1607,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Cosmic_Dragon__Ancient__Spellcaster__k02qUbpmQDjr0QX4.json
+++ b/packs/alien-core-bestiary/Cosmic_Dragon__Ancient__Spellcaster__k02qUbpmQDjr0QX4.json
@@ -1441,7 +1441,7 @@
           "value": "action"
         },
         "description": {
-          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The dragon can choose either option for each creature, regardless of their current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li>Graviton Each creature must succeed at a @Check[fortitude|dc:41] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p>Photon Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p><p></p></li></ul>",
+          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The dragon can choose either option for each creature, regardless of their current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li><strong>Graviton</strong> Each creature must succeed at a @Check[fortitude|dc:41] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p><strong>Photon</strong> Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p></li></ul>",
           "gm": ""
         },
         "publication": {
@@ -1483,9 +1483,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Cosmic_Dragon__Young__2xUsBYfaAcvd82UJ.json
+++ b/packs/alien-core-bestiary/Cosmic_Dragon__Young__2xUsBYfaAcvd82UJ.json
@@ -1565,7 +1565,7 @@
           "value": "action"
         },
         "description": {
-          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li>Graviton Each creature must succeed at a @Check[fortitude|dc:29] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p>Photon Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p><p></p></li></ul>",
+          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li><strong>Graviton</strong> Each creature must succeed at a @Check[fortitude|dc:29] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p><strong>Photon</strong> Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p></li></ul>",
           "gm": ""
         },
         "publication": {
@@ -1607,9 +1607,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Cosmic_Dragon__Young__Spellcaster__1RqCl3eyMXaPKaFZ.json
+++ b/packs/alien-core-bestiary/Cosmic_Dragon__Young__Spellcaster__1RqCl3eyMXaPKaFZ.json
@@ -1440,7 +1440,7 @@
           "value": "action"
         },
         "description": {
-          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li>Graviton Each creature must succeed at a @Check[fortitude|dc:29] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p>Photon Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p><p></p></li></ul>",
+          "value": "<p>The dragon imposes an effect on creatures within their attunement aura. The effect is based on the dragon's current attunement. The dragon can't use Stellar Pulse again for [[/gmr 1d4 #Recharge Stellar Pulse]]{1d4 rounds}.</p><ul><li><strong>Graviton</strong> Each creature must succeed at a @Check[fortitude|dc:29] save or be @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized} for 1 round.</li><li><p><strong>Photon</strong> Each creature becomes @UUID[Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl]{Quickened} and can use the extra action only to Stride or Strike.</p></li></ul>",
           "gm": ""
         },
         "publication": {
@@ -1482,9 +1482,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Crest_Eater_Necrograft_Zombie_F6GauwVhEtddvyqj.json
+++ b/packs/alien-core-bestiary/Crest_Eater_Necrograft_Zombie_F6GauwVhEtddvyqj.json
@@ -450,7 +450,7 @@
           "value": "reaction"
         },
         "description": {
-          "value": "<p>A necrograft zombie must use this reaction unless its necrograft is disabled</p><p><strong>Trigger</strong> The zombie is reduced to 0 Hit Points</p><hr /><p><strong>Effect</strong> The zombie rapidly decomposes into a heap of rotting biomass, dealing 2d8 poison and @Damage[2d8[void]|options:area-damage] damage in a @Template[type:emanation|distance:15] (@Check[reflex|dc:22|basic] save) and making that area hazardous terrain for 1 minute (@Damage[1d4[void]|options:area-damage] damage). This ability destroys any organic items on the zombie (including necrografts).</p>",
+          "value": "<p>A necrograft zombie must use this reaction unless its necrograft is disabled</p><p><strong>Trigger</strong> The zombie is reduced to 0 Hit Points</p><hr /><p><strong>Effect</strong> The zombie rapidly decomposes into a heap of rotting biomass, dealing 2d8 poison and @Damage[2d8[poison],2d8[void]|options:area-damage] damage in a @Template[type:emanation|distance:15] (@Check[reflex|dc:22|basic|options:area-effect] save) and making that area hazardous terrain for 1 minute (@Damage[1d4[void]|options:area-damage] damage). This ability destroys any organic items on the zombie (including necrografts).</p>",
           "gm": ""
         },
         "publication": {
@@ -489,9 +489,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0

--- a/packs/alien-core-bestiary/Crest_Eater_Necrograft_Zombie_F6GauwVhEtddvyqj.json
+++ b/packs/alien-core-bestiary/Crest_Eater_Necrograft_Zombie_F6GauwVhEtddvyqj.json
@@ -450,7 +450,7 @@
           "value": "reaction"
         },
         "description": {
-          "value": "<p>A necrograft zombie must use this reaction unless its necrograft is disabled</p><p><strong>Trigger</strong> The zombie is reduced to 0 Hit Points</p><hr /><p><strong>Effect</strong> The zombie rapidly decomposes into a heap of rotting biomass, dealing 2d8 poison and @Damage[2d8[poison],2d8[void]|options:area-damage] damage in a @Template[type:emanation|distance:15] (@Check[reflex|dc:22|basic|options:area-effect] save) and making that area hazardous terrain for 1 minute (@Damage[1d4[void]|options:area-damage] damage). This ability destroys any organic items on the zombie (including necrografts).</p>",
+          "value": "<p>A necrograft zombie must use this reaction unless its necrograft is disabled</p><p><strong>Trigger</strong> The zombie is reduced to 0 Hit Points</p><hr /><p><strong>Effect</strong> The zombie rapidly decomposes into a heap of rotting biomass, dealing @Damage[2d8[poison],2d8[void]|options:area-damage] damage in a @Template[type:emanation|distance:15] (@Check[reflex|dc:22|basic|options:area-effect] save) and making that area hazardous terrain for 1 minute (@Damage[1d4[void]|options:area-damage] damage). This ability destroys any organic items on the zombie (including necrografts).</p>",
           "gm": ""
         },
         "publication": {

--- a/packs/alien-core-bestiary/Cyanoscum_Bloom_BeqWprlTnTffXV0R.json
+++ b/packs/alien-core-bestiary/Cyanoscum_Bloom_BeqWprlTnTffXV0R.json
@@ -338,7 +338,7 @@
     },
     {
       "img": "systems/pf2e/icons/actions/Passive.webp",
-      "name": "Regeneration (Deactivated by Fire)",
+      "name": "Regeneration 5 (Deactivated by Fire)",
       "system": {
         "actionType": {
           "value": "passive"
@@ -385,7 +385,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
         "systemVersion": "7.6.2"
       },

--- a/packs/alien-core-bestiary/Cyanoscum_Bloom_BeqWprlTnTffXV0R.json
+++ b/packs/alien-core-bestiary/Cyanoscum_Bloom_BeqWprlTnTffXV0R.json
@@ -463,7 +463,7 @@
           "value": "passive"
         },
         "description": {
-          "value": "<p><strong>Saving Throw</strong> @Check[fortitude|dc:18]</p><p><strong>Maximum Duration</strong> 6 rounds</p><p><strong>Stage 1</strong>d4 poison damage and @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} (1 round)</p><p><strong>Stage 2</strong> @Damage[1d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 2} (1 round)</p><p><strong>Stage 3</strong> @Damage[1d8[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.6uEgoh53GbXuHpTF]{Paralyzed} (1 round)</p>",
+          "value": "<p><strong>Saving Throw</strong> @Check[fortitude|dc:18]</p><p><strong>Maximum Duration</strong> 6 rounds</p><p><strong>Stage 1 </strong>@Damage[1d4[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} (1 round)</p><p><strong>Stage 2</strong> @Damage[1d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 2} (1 round)</p><p><strong>Stage 3</strong> @Damage[1d8[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.6uEgoh53GbXuHpTF]{Paralyzed} (1 round)</p>",
           "gm": ""
         },
         "publication": {
@@ -504,9 +504,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "ownership": {
         "default": 0
@@ -521,7 +521,7 @@
           "value": "passive"
         },
         "description": {
-          "value": "<p>A cyanoscum can Squeeze through spaces that aren't airtight at half its Speed per round.</p>",
+          "value": "<p>A cyanoscum bloom can Squeeze through spaces that aren't airtight at half its Speed per round.</p>",
           "gm": ""
         },
         "publication": {
@@ -559,9 +559,9 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2"
+        "systemVersion": "7.8.0"
       },
       "_id": "BKl9kQcNoA94BZCT",
       "ownership": {

--- a/packs/alien-core-bestiary/Cyanoscum_pjh2PB4JwYlgMTwj.json
+++ b/packs/alien-core-bestiary/Cyanoscum_pjh2PB4JwYlgMTwj.json
@@ -315,7 +315,7 @@
     },
     {
       "img": "systems/pf2e/icons/actions/Passive.webp",
-      "name": "Regeneration (Deactivated by Fire)",
+      "name": "Regeneration 1 (Deactivated by Fire)",
       "system": {
         "actionType": {
           "value": "passive"
@@ -362,7 +362,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
         "systemVersion": "7.6.2"
       },

--- a/packs/alien-core-bestiary/Cybernetic_Zombie_dxbr3LNg0R66Aj1n.json
+++ b/packs/alien-core-bestiary/Cybernetic_Zombie_dxbr3LNg0R66Aj1n.json
@@ -637,7 +637,7 @@
           "value": "passive"
         },
         "description": {
-          "value": "<p>A cybernetic zombie's cybernetics can be disabled for 1 hour by a creature that succeeds at a DC 15 check to [[/act disable-device]] or Disable a System. Attempting to do so can typically be done only while within reach of the zombie and is a 2-action activity that has the manipulate trait. The cybernetics are also disabled for 1 hour if the zombie takes any electricity damage. A cybernetic zombie with disabled cybernetics is @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} and can't use any reactions.</p>",
+          "value": "<p>A cybernetic zombie's cybernetics can be disabled for 1 hour by a creature that succeeds at a DC 15 check to [[/act disable-device dc=15]] or Disable a System. Attempting to do so can typically be done only while within reach of the zombie and is a 2-action activity that has the manipulate trait. The cybernetics are also disabled for 1 hour if the zombie takes any electricity damage. A cybernetic zombie with disabled cybernetics is @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} and can't use any reactions.</p>",
           "gm": ""
         },
         "publication": {
@@ -673,9 +673,9 @@
       "sort": 0,
       "flags": {},
       "_stats": {
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
-        "systemVersion": "7.6.2",
+        "systemVersion": "7.8.0",
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null

--- a/packs/alien-core-bestiary/Warp_Troll_pU3d9PLxRDE6HSsL.json
+++ b/packs/alien-core-bestiary/Warp_Troll_pU3d9PLxRDE6HSsL.json
@@ -12,7 +12,7 @@
       },
       "ac": {
         "value": 23,
-        "details": ""
+        "details": "regeneration 15 (deactivated by sonic)"
       },
       "allSaves": {
         "value": ""
@@ -297,7 +297,7 @@
     },
     {
       "img": "systems/pf2e/icons/actions/Passive.webp",
-      "name": "Regeneration 15 (deactivated by sonic)",
+      "name": "Regeneration 15 (Deactivated by Sonic)",
       "system": {
         "actionType": {
           "value": "passive"
@@ -346,7 +346,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "pf2e",
         "systemVersion": "7.6.2"
       },
@@ -729,9 +729,9 @@
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null,
-    "coreVersion": "13.350",
+    "coreVersion": "13.351",
     "systemId": "pf2e",
-    "systemVersion": "7.6.2"
+    "systemVersion": "7.8.0"
   },
   "ownership": {
     "default": 0,


### PR DESCRIPTION
- Cosmic Dragons: Stellar Pulse formatting fixed
- Crest-Eater Necrograft Zombie: Added proper initial damage formula for Rapid Decomposition and area-effect option for its saving throw
- Cyanoscum: Renegeration value added (proabaly worth deleting ifrom HP details as most new creatures)
- Cyanoscum Bloom: Renegeration value added (proabaly worth deleting from HP details as most new creatures), fixed Cyanoscum Toxin damage and Squish decription
- Cybernetic Zombie: Disable a Device DC added
- Warp Troll: Fixed regeneration formatting