### PR TITLE
Added missing traditions to Share Pain

### DIFF
--- a/packs/spells/Share_Pain_EhN3GjdjXChMdiFk.json
+++ b/packs/spells/Share_Pain_EhN3GjdjXChMdiFk.json
@@ -26,7 +26,10 @@
         "mental"
       ],
       "rarity": "common",
-      "traditions": []
+      "traditions": [
+        "divine",
+        "occult"
+      ]
     },
     "publication": {
       "title": "Starfinder Player Core",


### PR DESCRIPTION
When creating some creatures I noticed that Share Pain didn't have any traditions listed, so I made a quick PR to address that.