### PR TITLE
Changed Flash Grenade Entries to line up with Player Core

### DIFF
--- a/packs/equipment/Flash_Grenade__Elite__zQlnRRTdC4pdwCvi.json
+++ b/packs/equipment/Flash_Grenade__Elite__zQlnRRTdC4pdwCvi.json
@@ -6,7 +6,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> dazzled for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:5] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round.</p>"
+      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:15] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 1 round, then @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round.</p>"
     },
     "rules": [],
     "slug": "flash-grenade-elite",
@@ -122,7 +122,7 @@
     "exportSource": null,
     "coreVersion": "13.351",
     "systemId": "pf2e",
-    "systemVersion": "7.7.4"
+    "systemVersion": "7.8.0"
   },
   "_id": "zQlnRRTdC4pdwCvi",
   "_key": "!items!zQlnRRTdC4pdwCvi"

--- a/packs/equipment/Flash_Grenade__Paragon__KtThxo7Jv7eYAiwR.json
+++ b/packs/equipment/Flash_Grenade__Paragon__KtThxo7Jv7eYAiwR.json
@@ -6,7 +6,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> dazzled for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:5] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round.</p>"
+      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 3 rounds, then @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:20] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 2 rounds.</p>"
     },
     "rules": [],
     "slug": "flash-grenade-paragon",
@@ -122,7 +122,7 @@
     "exportSource": null,
     "coreVersion": "13.351",
     "systemId": "pf2e",
-    "systemVersion": "7.7.4"
+    "systemVersion": "7.8.0"
   },
   "_id": "KtThxo7Jv7eYAiwR",
   "_key": "!items!KtThxo7Jv7eYAiwR"

--- a/packs/equipment/Flash_Grenade__Superior__z4hYYCFlMRypJ6Wd.json
+++ b/packs/equipment/Flash_Grenade__Superior__z4hYYCFlMRypJ6Wd.json
@@ -6,7 +6,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> dazzled for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:5] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round.</p>"
+      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 1 round</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:15] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 2 rounds.</p>"
     },
     "rules": [],
     "slug": "flash-grenade-superior",
@@ -122,7 +122,7 @@
     "exportSource": null,
     "coreVersion": "13.351",
     "systemId": "pf2e",
-    "systemVersion": "7.7.4"
+    "systemVersion": "7.8.0"
   },
   "_id": "z4hYYCFlMRypJ6Wd",
   "_key": "!items!z4hYYCFlMRypJ6Wd"

--- a/packs/equipment/Flash_Grenade__Tactical__0fZ9jBVvpljgAZC8.json
+++ b/packs/equipment/Flash_Grenade__Tactical__0fZ9jBVvpljgAZC8.json
@@ -125,7 +125,7 @@
     "exportSource": null,
     "coreVersion": "13.351",
     "systemId": "pf2e",
-    "systemVersion": "7.7.4"
+    "systemVersion": "7.8.0"
   },
   "_id": "0fZ9jBVvpljgAZC8",
   "_key": "!items!0fZ9jBVvpljgAZC8"

--- a/packs/equipment/Flash_Grenade__Ultimate__p4S4iBqbVkpvWP6Z.json
+++ b/packs/equipment/Flash_Grenade__Ultimate__p4S4iBqbVkpvWP6Z.json
@@ -6,7 +6,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> dazzled for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:5] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round.</p>"
+      "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Area Fire</p><p><strong>Critical</strong> @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 2 rounds</p><hr /><p>A flash grenade unleashes a blast of bright light that requires creatures in a @Template[burst|distance:20] to attempt a @Check[fortitude|against:class] save. On a failure, the creature is @UUID[Actor.GQkhsQNyNDtb8ce9.Item.9vqtuJWNCDbdrI0t]{Blinded} for 1 round, then @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round.</p>"
     },
     "rules": [],
     "slug": "flash-grenade-ultimate",
@@ -122,7 +122,7 @@
     "exportSource": null,
     "coreVersion": "13.351",
     "systemId": "pf2e",
-    "systemVersion": "7.7.4"
+    "systemVersion": "7.8.0"
   },
   "_id": "p4S4iBqbVkpvWP6Z",
   "_key": "!items!p4S4iBqbVkpvWP6Z"

--- a/packs/spells/Share_Pain_EhN3GjdjXChMdiFk.json
+++ b/packs/spells/Share_Pain_EhN3GjdjXChMdiFk.json
@@ -26,7 +26,10 @@
         "mental"
       ],
       "rarity": "common",
-      "traditions": []
+      "traditions": [
+        "divine",
+        "occult"
+      ]
     },
     "publication": {
       "title": "Starfinder Player Core",

--- a/packs/spells/Share_Pain_EhN3GjdjXChMdiFk.json
+++ b/packs/spells/Share_Pain_EhN3GjdjXChMdiFk.json
@@ -26,10 +26,7 @@
         "mental"
       ],
       "rarity": "common",
-      "traditions": [
-        "divine",
-        "occult"
-      ]
+      "traditions": []
     },
     "publication": {
       "title": "Starfinder Player Core",


### PR DESCRIPTION
I noticed that the Flash Grenade entries for Elite, Paragon, Superior, and Ultimate didn't line up with Player Core, so this PR should address that.